### PR TITLE
Only instantiate when we're doing our AJAX select

### DIFF
--- a/assets/js/customizer-ajax-select.js
+++ b/assets/js/customizer-ajax-select.js
@@ -19,6 +19,7 @@
 						s: search,
 						action: el.data('cas-action'),
 						_wpnonce: el.data('cas-nonce'),
+						doing_customizer_ajax_select: true,
 					}
 					return ajaxParams;
 				}

--- a/customizer-ajax-select.php
+++ b/customizer-ajax-select.php
@@ -30,7 +30,7 @@ spl_autoload_register( function( $class ) {
 
 add_action( 'admin_init', function(){
 	global $pagenow;
-	if ( 'admin-ajax.php' !== $pagenow ) {
+	if ( 'admin-ajax.php' !== $pagenow || empty( $_GET['doing_customizer_ajax_select'] ) ) {
 		return;
 	}
 	require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';


### PR DESCRIPTION
Otherwise, instantiating the class can cause problems with other
Customizer fields saving (e.g. widgets)
